### PR TITLE
Bugfix: Python 3.9 does not support | for types.

### DIFF
--- a/.github/workflows/publish_pypy.yml
+++ b/.github/workflows/publish_pypy.yml
@@ -1,0 +1,18 @@
+name: Publish to Guardrails Hub
+
+on:
+  workflow_dispatch:
+  push:
+    # Publish when new releases are tagged.
+    tags:
+      - '*'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build & Deploy
+        uses: guardrails-ai/guardrails/.github/actions/validator_pypi_publish@main
+        with:
+          guardrails_token: ${{ secrets.GR_GUARDRAILS_TOKEN }}
+          validator_id: guardrails/toxic_language

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toxic_language"
-version = "0.0.1"
+version = "0.0.2"
 description = "Validates whether the generated text is toxic."
 authors = [
     {name = "Guardrails AI", email = "contact@guardrailsai.com"}

--- a/validator/main.py
+++ b/validator/main.py
@@ -161,7 +161,7 @@ class ToxicLanguage(Validator):
         else:
             return self.validate_full_text(value, metadata)
 
-    def _inference_local(self, model_input: str | list) -> Any:
+    def _inference_local(self, model_input: Union[str, list]) -> Any:
         """Local inference method for the toxic language validator."""
 
         if isinstance(model_input, str):
@@ -173,7 +173,7 @@ class ToxicLanguage(Validator):
         
         return predictions
 
-    def _inference_remote(self, model_input: str | list) -> Any:
+    def _inference_remote(self, model_input: Union[str, list]) -> Any:
         """Remote inference method for the toxic language validator."""
 
         if isinstance(model_input, str):

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -1,4 +1,3 @@
-import nltk
 import detoxify
 
 # Download NLTK data if not already present


### PR DESCRIPTION
On Python 3.9 the '|' isn't supported for type unions.

```
python -m pdb -m guardrails hub install hub://guardrails/toxic_language
Traceback (most recent call last):
  File "/Users/josephcatrambone/.pyenv/versions/3.9.19/lib/python3.9/pdb.py", line 1703, in main
    runpy._get_module_details(mainpyfile)
  File "/Users/josephcatrambone/.pyenv/versions/3.9.19/lib/python3.9/runpy.py", line 147, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/Users/josephcatrambone/.pyenv/versions/3.9.19/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/Users/josephcatrambone/.virtualenvs/test_guardrails_cli/lib/python3.9/site-packages/guardrails/__init__.py", line 12, in <module>
    from guardrails.hub.install import install
  File "/Users/josephcatrambone/.virtualenvs/test_guardrails_cli/lib/python3.9/site-packages/guardrails/hub/__init__.py", line 9, in <module>
    from guardrails_grhub_toxic_language import ToxicLanguage
  File "/Users/josephcatrambone/.virtualenvs/test_guardrails_cli/lib/python3.9/site-packages/guardrails_grhub_toxic_language/__init__.py", line 1, in <module>
    from .main import ToxicLanguage
  File "/Users/josephcatrambone/.virtualenvs/test_guardrails_cli/lib/python3.9/site-packages/guardrails_grhub_toxic_language/main.py", line 21, in <module>
    class ToxicLanguage(Validator):
  File "/Users/josephcatrambone/.virtualenvs/test_guardrails_cli/lib/python3.9/site-packages/guardrails_grhub_toxic_language/main.py", line 164, in ToxicLanguage
    def _inference_local(self, model_input: str | list) -> Any:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

This does a quick replace of the '|' with an explicit union and adds the 'push to GR hub on tag'.